### PR TITLE
Fixed logo image path issue

### DIFF
--- a/PS_Controller.html
+++ b/PS_Controller.html
@@ -17,7 +17,7 @@
     <header>
         
         <div class="logo">
-          <img src="C:\Users\KIIT\OneDrive\Pictures\logo.png" alt="">
+           <img src="controller.png" alt="logo">
         </div>
 
         <div class="hamburger-menu">


### PR DESCRIPTION
Fixed incorrect local image path (C:\Users...) which was not working in browser.
Updated it to use a valid image so the logo displays correctly for all users.